### PR TITLE
chore: level up Copilot agent config

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,55 @@
+# Copilot Instructions — Macro Calendar (InsightsLog/Insights)
+
+## What This Repo Does
+A macroeconomic release calendar web app. Users track upcoming economic indicators (CPI, NFP, GDP, etc.), get alerts, manage watchlists, and access data via webhooks and REST API. Stack: Next.js 15 (App Router), Supabase (Postgres + Auth + Edge Functions), Tailwind CSS, TypeScript, Vercel.
+
+## Repo Layout
+```
+macro-calendar/          # Next.js app (the main product)
+  src/
+    app/                 # App Router pages & server actions
+      actions/           # Server actions (webhooks.ts, api-keys.ts, etc.)
+      api/               # API route handlers (/api/v1/*)
+      components/        # Shared UI components
+      admin/             # Admin-only pages
+      settings/          # User settings pages
+    lib/
+      supabase/          # Supabase clients (server.ts, client.ts, auth.ts)
+      env.ts             # Central env var config — ALWAYS use this
+      data-sources/      # Data acquisition modules (fred.ts, bls.ts, ecb.ts)
+  supabase/
+    migrations/          # SQL migrations (numbered 001_, 002_, etc.)
+    functions/           # Deno Edge Functions
+  scripts/               # Utility scripts (audit-db-permissions.mjs, etc.)
+AGENTS.md                # Coding agent rules (read this)
+TASKS_L4.md              # Current sprint tasks
+SPEC.md                  # Full product spec
+CHANGELOG.md             # Must update for every user-visible change
+```
+
+## How to Build & Test
+```bash
+cd macro-calendar
+npm ci                   # Install deps
+npm run build            # Build (must pass before PR)
+npm run lint             # ESLint (must pass)
+npm run test             # Vitest unit tests
+npm run audit:db-permissions  # Check migration SQL grants
+```
+
+## Key Conventions
+- **Env vars**: Never use `process.env.SOMETHING` directly. Add to `src/lib/env.ts` and import from there.
+- **Supabase clients**: Use `createSupabaseServerClient()` in server components/actions, `createSupabaseClientClient()` in client components. Never call Supabase directly from React components.
+- **Server actions**: All mutations go in `src/app/actions/`. Always validate with Zod. Always check `supabase.auth.getUser()` first.
+- **Migrations**: Name as `NNN_description.sql`. Next number = check highest existing in `supabase/migrations/`. Revoke anon/authenticated on sensitive tables; grant to service_role.
+- **Edge Functions**: Deno runtime. Import from `npm:` or `https://deno.land/x/`. No Node built-ins. Use `Deno.serve()`.
+- **TypeScript**: Strict mode. No `any`. Validate all external data with Zod.
+- **PR size**: One task per PR. Small and focused.
+
+## Database Schema Quick Reference
+Core tables: `indicators`, `releases`, `profiles`, `watchlist`, `alert_preferences`, `user_roles`, `audit_log`, `api_keys`, `request_logs`, `webhook_endpoints`, `webhook_deliveries`, `plans`, `subscriptions`, `organizations`, `organization_members`, `data_sources`, `sync_logs`
+
+RLS is enabled on all user-facing tables. `audit_log`, `request_logs`, `data_sources`, `sync_logs` are service_role only.
+
+## Current Focus: L4 — Data Acquisition
+See `TASKS_L4.md` for the active task list. Acceptance criteria are defined there. Key principle: **never invent data or claim real-time unless actually implemented.**

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,37 @@
+name: Copilot Setup Steps
+
+# This workflow pre-installs dependencies in the Copilot coding agent environment.
+# It runs before Copilot starts working on a task, saving time and reducing failures.
+# See: https://docs.github.com/en/copilot/how-tos/use-copilot-agents/coding-agent/customizing-the-development-environment-for-copilot-coding-agent
+
+on:
+  workflow_dispatch: {}
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: macro-calendar/package-lock.json
+
+      - name: Install dependencies
+        working-directory: macro-calendar
+        run: npm ci
+
+      - name: Setup Deno (for Edge Functions)
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Install Supabase CLI
+        run: |
+          curl -fsSL https://github.com/supabase/cli/releases/latest/download/supabase_linux_amd64.tar.gz | tar -xz
+          sudo mv supabase /usr/local/bin/
+          supabase --version

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,56 +1,50 @@
-# Agent Rules
+# Agent Rules — Macro Calendar
 
-You are working in a production-bound repo. Follow these rules:
+You are working in a production-bound repo. Read `.github/copilot-instructions.md` first for full context.
 
 ## Scope
+- Current milestone: **L4** — data acquisition, mobile app, calendar integrations, historical data API, advanced analytics.
 - If asked to do something outside L4, stop and propose an issue for L5 instead.
-- L4 scope: data acquisition, mobile app, calendar integrations, historical data API, advanced analytics
 
 ## Workflow
-- Small changes only: one task per PR.
-- Before coding: restate acceptance criteria + test steps.
+- One task per PR. Small and focused.
+- Before coding: restate the acceptance criteria from the issue.
 - After coding: list files changed + how to test + risks/edge cases.
-- Update CHANGELOG.md for every user-visible change.
-- When you identify an L4 improvement during work, append it to BACKLOG.md under the appropriate section.
+- Update `CHANGELOG.md` for every user-visible change.
+- Link PRs to issues: "Closes #N" in the PR body.
 
-## GitHub Issues & PRs
-- Use issue templates when creating issues (Bug, Feature, Task)
-- Apply appropriate labels to issues and PRs
-- Link PRs to issues with "Closes #123" or "Fixes #123"
-- Assign issues to milestones (L3, L4) based on scope
-
-## MCP Tools
-
-Use MCP (Model Context Protocol) tools when available for these operations:
+## MCP Tools (use these — don't guess)
 
 ### GitHub MCP
-- **CI failures**: Use `list_workflow_runs` and `get_job_logs` to investigate build/test failures instead of guessing.
-- **PRs and issues**: Use `list_pull_requests`, `search_issues`, or `pull_request_read` to understand context.
-- **Code search**: Use `search_code` for finding patterns across the codebase.
+- `list_workflow_runs` / `get_job_logs` — investigate CI failures before guessing at fixes.
+- `list_pull_requests` / `search_issues` / `pull_request_read` — understand context.
+- `search_code` — find patterns across the codebase without grepping locally.
 
 ### Supabase MCP
-- **Schema changes**: Use `list_tables` and `execute_sql` to verify table structure before writing migrations.
-- **Documentation**: Use `search_docs` to look up Supabase features (auth, RLS, functions, etc.) before implementing.
-- **Debugging**: Use `get_logs` to investigate auth, storage, or edge function errors.
-- **Edge Functions**: Use for email alert triggers and webhook handling (L2 feature).
+- `list_tables` / `execute_sql` — verify schema before writing migrations.
+- `search_docs` — look up Supabase features (auth, RLS, edge functions) before implementing.
+- `get_logs` — debug auth, storage, or edge function errors.
 
 ### Vercel MCP
-- **Deployments**: Use `list_deployments` and `get_deployment` to check deployment status.
-- **Environment**: Use `list_environment_variables` to verify env vars are configured.
-- **Domains**: Use `list_project_domains` to check domain configuration.
+- `list_deployments` / `get_deployment` — check deployment status after pushing.
+- `list_environment_variables` — verify env vars are configured.
 
-## Coding standards
-- TypeScript everywhere.
-- Validate external inputs with zod.
-- No "magic" environment variable usage: centralize in src/lib/env.ts.
-- No direct DB calls in React components; use server actions or route handlers.
-- Prefer simple, boring dependencies.
+## Coding Standards
+- TypeScript everywhere. No `any`. Strict mode.
+- Validate external inputs with Zod.
+- **Env vars**: always centralize in `src/lib/env.ts`. Never use `process.env.*` inline.
+- No direct DB calls in React components — use server actions or route handlers.
+- Prefer boring, stable dependencies.
 
-## Safety / correctness
-- Never invent data sources or claim "real-time" unless implemented.
+## Safety
+- Never invent data sources or claim real-time unless actually implemented.
 - If uncertain, choose the simplest safe default and document it.
+- RLS must be enforced for all user-facing tables.
+- Service_role only for: `audit_log`, `request_logs`, `data_sources`, `sync_logs`.
 
 ## Definition of Done
-- Lint passes
-- Build passes
-- Manual test steps written and verified
+- [ ] `npm run lint` passes
+- [ ] `npm run build` passes
+- [ ] `npm run test` passes (or new tests added)
+- [ ] Manual test steps written in PR description
+- [ ] `CHANGELOG.md` updated (if user-visible)


### PR DESCRIPTION
Adds the three key files that unlock Copilot coding agent's full potential:

- `.github/copilot-instructions.md` — repo onboarding doc Copilot reads on every task (stack, conventions, file layout, build commands)
- `.github/workflows/copilot-setup-steps.yml` — pre-installs Node/Deno/Supabase CLI in Copilot's sandbox so it doesn't waste time setting up
- `AGENTS.md` — upgraded with MCP tools config (GitHub, Supabase, Vercel) and cleaner DoD checklist

This is the meta-work that makes every subsequent Copilot PR higher quality and faster.